### PR TITLE
Add SWI, RSC handlers, and decoder for Data transfer instructions, with an enum for their opcodes

### DIFF
--- a/include/isa_helper.h
+++ b/include/isa_helper.h
@@ -10,6 +10,8 @@
 #define CPSR_C 29
 #define CPSR_V 28
 
+#define S_BIT 20
+
 #define L_BIT 20
 #define W_BIT 21
 #define B_BIT 22

--- a/isa.c
+++ b/isa.c
@@ -101,7 +101,7 @@ static void exec_RSC(uint32_t instruction)
 {
     if (condition_check(curr_state, get_bits(instruction, 31, 28))) {
         struct ShifterOperand * shiftop;
-        shiftop = shifter_operand(curr_state, get_bits(instruction, 11, 0));
+        shiftop = shifter_operand(curr_state, instruction);
         uint8_t rd_id = get_bits(instruction, 15, 12);
         uint8_t rn_id = get_bits(instruction, 19, 16);
         uint32_t rn_val = curr_state.regs[rn_id];

--- a/isa.c
+++ b/isa.c
@@ -1,5 +1,5 @@
 #include "isa_helper.h"
-
+#include "isa.h"
 
 /* Instructions to implement:
  * ADC ADD AND B BIC

--- a/isa.c
+++ b/isa.c
@@ -57,7 +57,7 @@ static void decode_and_exec(uint32_t instruction)
         }
     } else if (get_bits(instruction, 27, 26) ==  0x0) {
         // DATA PROCESSING INSTRUCTIONS
-        uint8_t opcode = get_bits(instruction, 24, 21);
+        enum DataProcOpcode opcode = get_bits(instruction, 24, 21);
         switch (opcode) {
             case OP_RSC: exec_RSC(instruction); break;
         }

--- a/isa.c
+++ b/isa.c
@@ -9,11 +9,19 @@
  * STRB SUB TEQ TST SWI
  */
 
+enum DataProcOpcode {
+    OP_AND, OP_EOR, OP_SUB, OP_RSB,
+    OP_ADD, OP_ADC, OP_SBC, OP_RSC,
+    OP_TST, OP_TEQ, OP_CMP, OP_CMN,
+    OP_ORR, OP_MOV, OP_BIC, OP_MVN,
+};
+
 static void decode_and_exec(uint32_t instruction);
 static void exec_LDR(uint32_t instruction);
 static void exec_STR(uint32_t instruction);
 static void exec_STRB(uint32_t instruction);
 static void exec_SWI(uint32_t instruction);
+static void exec_RSC(uint32_t instruction);
 
 static struct CPUState next_state, curr_state;
 
@@ -47,6 +55,12 @@ static void decode_and_exec(uint32_t instruction)
                 exec_STRB(instruction);
             }
         }
+    } else if (get_bits(instruction, 27, 26) ==  0x0) {
+        // DATA PROCESSING INSTRUCTIONS
+        uint8_t opcode = get_bits(instruction, 24, 21);
+        switch (opcode) {
+            case OP_RSC: exec_RSC(instruction); break;
+        }
     } else if (get_bits(instruction, 27, 24) == 0xf) { // SWI
         exec_SWI(instruction);
     }
@@ -79,6 +93,29 @@ static void exec_STRB(uint32_t instruction)
         uint8_t data = curr_state.regs[rd_id] & 0xff; // LSB byte of reg
         uint32_t address = ld_str_addr_mode(curr_state, &next_state, instruction);
         mem_write_8(address, data);
+    }
+}
+
+// reverse subtract, with carry
+static void exec_RSC(uint32_t instruction)
+{
+    if (condition_check(curr_state, get_bits(instruction, 31, 28))) {
+        struct ShifterOperand * shiftop;
+        shiftop = shifter_operand(curr_state, get_bits(instruction, 11, 0));
+        uint8_t rd_id = get_bits(instruction, 15, 12);
+        uint8_t rn_id = get_bits(instruction, 19, 16);
+        uint32_t rn_val = curr_state.regs[rn_id];
+        bool carry = get_bit(curr_state.CPSR, CPSR_C);
+        uint32_t rd_val = shiftop->shifter_operand - rn_val - !carry;
+        next_state.regs[rd_id] = rd_val;
+        if (get_bit(instruction, S_BIT) == 1) {
+            set_bit(&next_state.CPSR, CPSR_N, get_bit(rd_val, 31));
+            set_bit(&next_state.CPSR, CPSR_Z, (rd_val ? 0 : 1));
+            set_bit(&next_state.CPSR, CPSR_C,
+                    !check_sub_borrow(rd_val, rn_val + !carry)); // c = !b
+            set_bit(&next_state.CPSR, CPSR_V,
+                    check_overflow(rd_val, -(rn_val + !carry)));
+        }
     }
 }
 


### PR DESCRIPTION
compiles and decoder tested.
also tested simulator halting when `swi #10` is executed
